### PR TITLE
Fix Bintray related properties in preparation for the release

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,5 +14,5 @@ POM_LICENCE_NAME=The MIT License (MIT)
 POM_LICENCE_URL=https://opensource.org/licenses/MIT
 POM_LICENCE_DIST=repo
 
-POM_DEVELOPER_ID=macroing
+POM_DEVELOPER_ID=macroing-org
 POM_DEVELOPER_NAME=J&#246;rgen Lundgren

--- a/gradle/gradle-mvn-push.gradle
+++ b/gradle/gradle-mvn-push.gradle
@@ -33,7 +33,7 @@ def findProperty(String key) {
 }
 
 def getReleaseRepositoryUrl() {
-    return findProperty('RELEASE_REPOSITORY_URL') ?: "https://api.bintray.com/maven/macroing/maven/cel4j-artifact"
+    return findProperty('RELEASE_REPOSITORY_URL') ?: "https://api.bintray.com/maven/macroing-org/maven/CEL4J-Artifact"
 }
 
 def getSnapshotRepositoryUrl() {


### PR DESCRIPTION
In order to make the CEL4J-Artifact release available in `jcenter` and `mavenCentral`

- Renames package from `org.macroing.cel4j` to `org.cel4j` so that matches the `cel4j` Bintray organization https://bintray.com/cel4j and the `CEL4J-Artifact` repo https://bintray.com/cel4j/CEL4J-Artifact recently created

@macroing could you check that everything is still working/I didn't miss anything?

